### PR TITLE
Add stacktrace to logging in top-level exception-handling

### DIFF
--- a/src/soda_curation/main.py
+++ b/src/soda_curation/main.py
@@ -228,7 +228,7 @@ def main(zip_path: str, config_path: str, output_path: Optional[str] = None) -> 
             return output_json
 
         except Exception as e:
-            logger.error(f"Pipeline failed: {str(e)}")
+            logger.error(f"Pipeline failed: {str(e)}", exc_info=True)
             error_json = json.dumps({"error": str(e)})
             if output_path:
                 output_dir = Path(output_path).parent
@@ -237,7 +237,7 @@ def main(zip_path: str, config_path: str, output_path: Optional[str] = None) -> 
                     f.write(error_json)
             return error_json
     except Exception as e:
-        logger.exception(f"Pipeline failed: {str(e)}")
+        logger.exception(f"Pipeline failed: {str(e)}", exc_info=True)
         return json.dumps({"error": str(e)})
 
     finally:


### PR DESCRIPTION
This change makes debugging pipeline failures much easier. We go from this:
```
2025-09-10 15:15:31 - src.soda_curation.pipeline.assign_panel_source.assign_panel_source_openai - ERROR - Error calling OpenAI API: Request timed out.
2025-09-10 15:15:31 - __main__ - ERROR - Pipeline failed: 'NoneType' object has no attribute 'not_assigned_files'
```

To this:
```
2025-09-10 15:15:31 - src.soda_curation.pipeline.assign_panel_source.assign_panel_source_openai - ERROR - Error calling OpenAI API: Request timed out.
2025-09-10 15:15:31 - __main__ - ERROR - Pipeline failed: 'NoneType' object has no attribute 'not_assigned_files'
Traceback (most recent call last):
  File "/app/src/soda_curation/main.py", line 157, in main
    processed_figures = panel_source_assigner.assign_panel_source(
  File "/app/src/soda_curation/pipeline/assign_panel_source/assign_panel_source_base.py", line 82, in assign_panel_source
    self._assign_to_figure(figure)
  File "/app/src/soda_curation/pipeline/assign_panel_source/assign_panel_source_base.py", line 139, in _assign_to_figure
    figure, panels, assigned_files_list.not_assigned_files
AttributeError: 'NoneType' object has no attribute 'not_assigned_files'
```