### PR TITLE
Fix JSON error in identifiers.json

### DIFF
--- a/src/soda_curation/pipeline/data_availability/identifiers.json
+++ b/src/soda_curation/pipeline/data_availability/identifiers.json
@@ -465,7 +465,7 @@
       "identifiers_pattern": "https://identifiers.org/massive:",
       "local_unique_identifier_pattern": "^MSV\\d+$",
       "sample_id": "MSV000082131",
-      "sample_identifiers_url": "sample_identifiers_url": "https://identifiers.org/massive:MSV000082131",
+      "sample_identifiers_url": "https://identifiers.org/massive:MSV000082131",
       "sample_extertnal_url": "https://massive.ucsd.edu/ProteoSAFe/QueryMSV?id=MSV000082131"
     },
     {


### PR DESCRIPTION
This error didn't cause the pipeline to fail, but it did cause an incomplete prompt to be sent to the model without any database info (`src/soda_curation/pipeline/data_availability/data_availability_openai.py#49`):
```
        except Exception as e:
            logger.error(f"Error loading database registry: {str(e)}")
            return {"databases": []}
```

That might be the cause for the identifiers.org prefix occasionally not being used.